### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ narray.to_arrow  # -> An object of Arrow::Tensor
 
 ## Dependencies
 
-* [Red Arrow](https://github.com/red-data-tools/red-arrow)
+* [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow)
 
-* [Numo::NArray](http://ruby-numo.github.io/narray/)
+* [Numo::NArray](https://github.com/ruby-numo/numo-narray)
 
 ## Authors
 


### PR DESCRIPTION
* Update Red Arrow link
* Changed NArray homepage link to Github. This is because it has more up-to-date information than the homepage.