### PR TITLE
Make CI work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test with Docker
+        run : |
+          docker build -t red-data-tools/red-arrow-numo-narray .
+          docker run red-data-tools/red-arrow-numo-narray /bin/sh -c "bundle exec rake"


### PR DESCRIPTION
Hi.
I noticed that TravisCI wasn't working, I tried writing Github Actions, but it looks like I need to fix the Dockerfile.
The error log is as follows (on my local computer)

```
docker build -t red-data-tools/red-arrow-numo-narray .
```

```
Sending build context to Docker daemon  188.9kB
Step 1/7 : FROM ruby:latest
latest: Pulling from library/ruby
0bc3020d05f1: Pull complete 
a110e5871660: Pull complete 
83d3c0fa203a: Pull complete 
a8fd09c11b02: Pull complete 
14feb89c4a52: Pull complete 
958d2475f181: Pull complete 
d8dbee04da24: Pull complete 
349608c7a8bb: Pull complete 
Digest: sha256:34bb95c8eefc62aaa1c83a13ab0e32215f929eecd3d21c3768be807d17fb2734
Status: Downloaded newer image for ruby:latest
 ---> 443a01e9df04
Step 2/7 : MAINTAINER Sutou Kouhei <kou@clear-code.com>
 ---> Running in ef116df0c1db
Removing intermediate container ef116df0c1db
 ---> e5d222fd2099
Step 3/7 : RUN   apt update &&   apt install -y     apt-transport-https     curl     gnupg     lsb-release &&   curl     --output /usr/share/keyrings/apache-arrow-keyring.gpg     https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-keyring.gpg &&   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apache-arrow-keyring.gpg] https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main"     > /etc/apt/sources.list.d/apache-arrow.list &&   apt update &&   apt install -y libarrow-glib-dev
 ---> Running in 12f1a7646196

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Get:4 http://security.debian.org/debian-security buster/updates/main amd64 Packages [293 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7907 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [15.2 kB]
Fetched 8454 kB in 5s (1878 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
1 package can be upgraded. Run 'apt list --upgradable' to see it.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
curl is already the newest version (7.64.0-4+deb10u2).
gnupg is already the newest version (2.2.12-1+deb10u1).
The following additional packages will be installed:
  distro-info-data
Suggested packages:
  lsb
The following NEW packages will be installed:
  apt-transport-https distro-info-data lsb-release
0 upgraded, 3 newly installed, 0 to remove and 1 not upgraded.
Need to get 184 kB of archives.
After this operation, 236 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main amd64 apt-transport-https all 1.8.2.3 [149 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 distro-info-data all 0.41+deb10u3 [6640 B]
Get:3 http://deb.debian.org/debian buster/main amd64 lsb-release all 10.2019051400 [27.5 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 184 kB in 0s (2761 kB/s)
Selecting previously unselected package apt-transport-https.
(Reading database ... 23987 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_1.8.2.3_all.deb ...
Unpacking apt-transport-https (1.8.2.3) ...
Selecting previously unselected package distro-info-data.
Preparing to unpack .../distro-info-data_0.41+deb10u3_all.deb ...
Unpacking distro-info-data (0.41+deb10u3) ...
Selecting previously unselected package lsb-release.
Preparing to unpack .../lsb-release_10.2019051400_all.deb ...
Unpacking lsb-release (10.2019051400) ...
Setting up apt-transport-https (1.8.2.3) ...
Setting up distro-info-data (0.41+deb10u3) ...
Setting up lsb-release (10.2019051400) ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0     18      0 --:--:-- --:--:-- --:--:--    18

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Hit:1 http://deb.debian.org/debian buster InRelease
Hit:2 http://deb.debian.org/debian buster-updates InRelease
Hit:3 http://security.debian.org/debian-security buster/updates InRelease
Err:4 https://dl.bintray.com/apache/arrow/debian buster InRelease
  403  Forbidden [IP: 52.37.31.3 443]
Reading package lists...
E: Failed to fetch https://dl.bintray.com/apache/arrow/debian/dists/buster/InRelease  403  Forbidden [IP: 52.37.31.3 443]
E: The repository 'https://dl.bintray.com/apache/arrow/debian buster InRelease' is not signed.
The command '/bin/sh -c apt update &&   apt install -y     apt-transport-https     curl     gnupg     lsb-release &&   curl     --output /usr/share/keyrings/apache-arrow-keyring.gpg     https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-keyring.gpg &&   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apache-arrow-keyring.gpg] https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main"     > /etc/apt/sources.list.d/apache-arrow.list &&   apt update &&   apt install -y libarrow-glib-dev' returned a non-zero code: 100
```